### PR TITLE
Low Eth Alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 cas
 ceramic
-

--- a/alertmanager-discord/Dockerfile
+++ b/alertmanager-discord/Dockerfile
@@ -1,6 +1,6 @@
 # Built following https://medium.com/@chemidy/create-the-smallest-and-secured-golang-docker-image-based-on-scratch-4752223b7324
 
-FROM golang:alpine as builder
+FROM golang:1.15-alpine as builder
 # Install SSL ca certificates
 RUN apk update && apk add git && apk add ca-certificates
 # Create appuser

--- a/alertmanager-discord/Dockerfile
+++ b/alertmanager-discord/Dockerfile
@@ -19,7 +19,6 @@ COPY --from=builder /etc/passwd /etc/passwd
 # Copy our static executable
 COPY --from=builder /go/bin/alertmanager-discord /go/bin/alertmanager-discord
 
-ENV LISTEN_ADDRESS=0.0.0.0:9096
 EXPOSE 9096
 USER appuser
 ENTRYPOINT ["/go/bin/alertmanager-discord"]

--- a/alertmanager-discord/README.md
+++ b/alertmanager-discord/README.md
@@ -1,7 +1,8 @@
 # alertmanager-discord
 
 1. Set LISTEN_ADDRESS environment variable (e.g. `127.0.0.1:9096`)
-1. Set DISCORD_WEBHOOK environment variable
+1. Set DISCORD_WEBHOOK_URL environment variable
+1. Set ENV environment variable
 1. Configure an alertmanager receiver
 
 ```yaml

--- a/alertmanager-discord/README.md
+++ b/alertmanager-discord/README.md
@@ -1,7 +1,8 @@
 # alertmanager-discord
 
+1. Set LISTEN_ADDRESS environment variable (e.g. `127.0.0.1:9096`)
 1. Set DISCORD_WEBHOOK environment variable
-2. Configure an alertmanager receiver
+1. Configure an alertmanager receiver
 
 ```yaml
 receivers:

--- a/alertmanager-discord/main.go
+++ b/alertmanager-discord/main.go
@@ -46,25 +46,24 @@ const defaultListenAddress = "127.0.0.1:9096"
 
 func main() {
 	env := os.Getenv("ENV")
-	discordWebhookUrl := os.Getenv("DISCORD_WEBHOOK")
+	discordWebhookUrl := os.Getenv("DISCORD_WEBHOOK_URL")
 	listenAddress := os.Getenv("LISTEN_ADDRESS")
 
 	if env == "" {
 		env = "DEV"
-	} else {
-		env = strings.ToUpper(env)
 	}
+	env = strings.ToUpper(env)
 
 	if discordWebhookUrl == "" {
-		log.Fatalf("Environment variable 'DISCORD_WEBHOOK' not found.")
+		log.Fatalf("Environment variable DISCORD_WEBHOOK_URL not found.")
 	}
 	_, err := url.Parse(discordWebhookUrl)
 	if err != nil {
-		log.Fatalf("Invalid url for DISCORD_WEBHOOK.")
+		log.Fatalf("Invalid url for DISCORD_WEBHOOK_URL.")
 	}
 	re := regexp.MustCompile(`https://discord(?:app)?.com/api/webhooks/[0-9]{18}/[a-zA-Z0-9_-]+`)
 	if ok := re.Match([]byte(discordWebhookUrl)); !ok {
-		log.Printf("Invalid url for DISCORD_WEBHOOK.")
+		log.Printf("Invalid url for DISCORD_WEBHOOK_URL.")
 	}
 
 	if listenAddress == "" {

--- a/alertmanager-discord/main.go
+++ b/alertmanager-discord/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"flag"
 	"io"
 	"io/ioutil"
 	"log"
@@ -11,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 )
 
 // Discord color values
@@ -20,6 +20,17 @@ const (
 	ColorGrey  = 9807270
 )
 
+type discordMessage struct {
+	Username string         `json:"username"`
+	Embeds   []discordEmbed `json:"embeds"`
+}
+
+type discordEmbed struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Color       int    `json:"color"`
+}
+
 type alertManagerData struct {
 	Username    string                   `json:"username"`
 	Attachments []alertManagerAttachment `json:"attachments"`
@@ -27,45 +38,46 @@ type alertManagerData struct {
 
 type alertManagerAttachment struct {
 	Title string `json:"title"`
+	Text  string `json:"text"`
+	Color string `json:"color"`
 }
 
 const defaultListenAddress = "127.0.0.1:9096"
 
 func main() {
-	envWhURL := os.Getenv("DISCORD_WEBHOOK")
-	whURL := flag.String("webhook.url", envWhURL, "Discord WebHook URL.")
+	env := os.Getenv("ENV")
+	discordWebhookUrl := os.Getenv("DISCORD_WEBHOOK")
+	listenAddress := os.Getenv("LISTEN_ADDRESS")
 
-	envListenAddress := os.Getenv("LISTEN_ADDRESS")
-	listenAddress := flag.String("listen.address", envListenAddress, "Address:Port to listen on.")
-
-	flag.Parse()
-
-	if *whURL == "" {
-		log.Fatalf("Environment variable 'DISCORD_WEBHOOK' or CLI parameter 'webhook.url' not found.")
+	if env == "" {
+		env = "DEV"
+	} else {
+		env = strings.ToUpper(env)
 	}
 
-	if *listenAddress == "" {
-		*listenAddress = defaultListenAddress
+	if discordWebhookUrl == "" {
+		log.Fatalf("Environment variable 'DISCORD_WEBHOOK' not found.")
 	}
-
-	_, err := url.Parse(*whURL)
+	_, err := url.Parse(discordWebhookUrl)
 	if err != nil {
-		log.Fatalf("The Discord WebHook URL doesn't seem to be a valid URL.")
+		log.Fatalf("Invalid url for DISCORD_WEBHOOK.")
 	}
-
 	re := regexp.MustCompile(`https://discord(?:app)?.com/api/webhooks/[0-9]{18}/[a-zA-Z0-9_-]+`)
-	if ok := re.Match([]byte(*whURL)); !ok {
-		log.Printf("The Discord WebHook URL doesn't seem to be valid.")
+	if ok := re.Match([]byte(discordWebhookUrl)); !ok {
+		log.Printf("Invalid url for DISCORD_WEBHOOK.")
 	}
 
-	log.Printf("Listening on: %s", *listenAddress)
-	http.ListenAndServe(*listenAddress, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	if listenAddress == "" {
+		listenAddress = defaultListenAddress
+	}
+	log.Printf("Listening on: %s", listenAddress)
+	http.ListenAndServe(listenAddress, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Received request")
 		requestBody, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			panic(err)
 		} else {
-			log.Printf("Payload: %s", requestBody)
+			log.Printf("Request body: %s", requestBody)
 		}
 
 		data := alertManagerData{}
@@ -74,17 +86,29 @@ func main() {
 			panic(err)
 		}
 
-		postBody, _ := json.Marshal(map[string][]alertManagerAttachment{
-			"embeds": data.Attachments,
-		})
-		payload := bytes.NewBuffer(postBody)
-		handlePost(*whURL, payload)
+		var embeds []discordEmbed
+		for _, obj := range data.Attachments {
+			var color = ColorGreen
+			if obj.Color == "danger" {
+				color = ColorRed
+			}
+			embed := discordEmbed{
+				env + " " + obj.Title,
+				obj.Text,
+				color,
+			}
+			embeds = append(embeds, embed)
+		}
 
-		// testBody, _ := json.Marshal(map[string]string{
-		// 	"content": "Testy test test",
-		// })
-		// testPayload := bytes.NewBuffer(testBody)
-		// handlePost(*whURL, testPayload)
+		message := discordMessage{
+			data.Username,
+			embeds,
+		}
+
+		responseBody, _ := json.Marshal(message)
+		log.Printf("Response body: %s", responseBody)
+		payload := bytes.NewBuffer(responseBody)
+		handlePost(discordWebhookUrl, payload)
 	}))
 }
 

--- a/alertmanager/Dockerfile
+++ b/alertmanager/Dockerfile
@@ -1,4 +1,4 @@
 FROM prom/alertmanager
 COPY *config.yaml /etc/alertmanager/
 ENTRYPOINT [ "/bin/alertmanager" ]
-CMD [ "--config.file=/etc/alertmanager/local-config.yaml", "--cluster.listen-address=\"\"", "--log.level=debug" ]
+CMD [ "--config.file=/etc/alertmanager/config.yaml", "--cluster.listen-address=", "--log.level=debug" ]

--- a/alertmanager/config.yaml
+++ b/alertmanager/config.yaml
@@ -54,3 +54,4 @@ receivers:
 - name: 'discord'
   slack_configs:
   - api_url: http://127.0.0.1:9096
+    text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"

--- a/alertmanager/config.yaml
+++ b/alertmanager/config.yaml
@@ -54,4 +54,5 @@ receivers:
 - name: 'discord'
   slack_configs:
   - api_url: http://127.0.0.1:9096
-    text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+    title: "[{{ toUpper .Status }}:{{ len .Alerts }}] {{ .GroupLabels.alertname }}"
+    text: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n\n{{ end }}"

--- a/alertmanager/local-config.yaml
+++ b/alertmanager/local-config.yaml
@@ -112,6 +112,7 @@ receivers:
   slack_configs:
   # - send_resolved: true
   - api_url: http://alertmanager-discord:9096
+    text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
   # url: $DISCORD_WEBHOOK_URL
   # - max_alerts: 5
 

--- a/alertmanager/local-config.yaml
+++ b/alertmanager/local-config.yaml
@@ -112,7 +112,8 @@ receivers:
   slack_configs:
   # - send_resolved: true
   - api_url: http://alertmanager-discord:9096
-    text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+    title: "[{{ toUpper .Status }}:{{ len .Alerts }}] {{ .GroupLabels.alertname }}"
+    text: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}"
   # url: $DISCORD_WEBHOOK_URL
   # - max_alerts: 5
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,13 +8,15 @@ services:
     build: ./alertmanager
     ports:
       - "9093:9093"
-    command: ["--config.file=/etc/alertmanager/local-config.yaml", "--cluster.listen-address=\"\"", "--log.level=debug"]
+    command: ["--config.file=/etc/alertmanager/local-config.yaml", "--cluster.listen-address=", "--log.level=debug"]
   alertmanager-discord:
     build: ./alertmanager-discord
     ports:
       - "9096:9096"
     environment:
+      - LISTEN_ADDRESS=0.0.0.0:9096
       - DISCORD_WEBHOOK=${DISCORD_WEBHOOK_URL}
+      - ENV=dev
   loki:
     build: ./loki
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "9096:9096"
     environment:
       - LISTEN_ADDRESS=0.0.0.0:9096
-      - DISCORD_WEBHOOK=${DISCORD_WEBHOOK_URL}
+      - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
       - ENV=dev
   loki:
     build: ./loki

--- a/loki/.dockerignore
+++ b/loki/.dockerignore
@@ -1,0 +1,1 @@
+rules/test.yaml

--- a/loki/rules/.gitignore
+++ b/loki/rules/.gitignore
@@ -1,1 +1,0 @@
-test.yaml

--- a/loki/rules/eth-balance.yaml
+++ b/loki/rules/eth-balance.yaml
@@ -12,4 +12,5 @@ groups:
             severity: critical
             category: cas
         annotations:
-          summary: "CAS ETH balance is below 1M gwei"
+          description: "CAS ETH balance in gwei: {{ $labels.balance }}"
+          summary: "CAS ETH balance below 2B gwei"

--- a/loki/rules/eth-balance.yaml
+++ b/loki/rules/eth-balance.yaml
@@ -1,12 +1,12 @@
 groups:
   - name: CASEthBalance
-    interval: 1s
+    interval: 10s
     rules:
       - alert: CASLowEthBalance
         expr: |
           sum by (job)
-            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance > 1000000 [1s]))
-            > 1
+            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance < 20000000000 [1h]))
+            > 0
         for: 1s
         labels:
             severity: critical

--- a/loki/rules/eth-balance.yaml
+++ b/loki/rules/eth-balance.yaml
@@ -5,7 +5,7 @@ groups:
       - alert: CASLowEthBalance
         expr: |
           sum by (job)
-            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance < 1000000 [1s]))
+            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance > 1000000 [1s]))
             > 1
         for: 1s
         labels:

--- a/loki/rules/eth-balance.yaml
+++ b/loki/rules/eth-balance.yaml
@@ -4,13 +4,13 @@ groups:
     rules:
       - alert: CASLowEthBalance
         expr: |
-          sum by (job)
-            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance < 20000000000 [1h]))
+          sum by (job, balance)
+            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance < 20000000000 [10m]))
             > 0
         for: 1s
         labels:
             severity: critical
             category: cas
         annotations:
-          description: "CAS ETH balance in gwei: {{ $labels.balance }}"
           summary: "CAS ETH balance below 2B gwei"
+          description: "Balance (gwei): {{ $labels.balance }}"

--- a/loki/rules/eth-balance.yaml
+++ b/loki/rules/eth-balance.yaml
@@ -5,12 +5,12 @@ groups:
       - alert: CASLowEthBalance
         expr: |
           sum by (job, balance)
-            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance < 20000000000 [10m]))
+            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance < 1000000 [10m]))
             > 0
         for: 1s
         labels:
             severity: critical
             category: cas
         annotations:
-          summary: "CAS ETH balance below 2B gwei"
+          summary: "CAS ETH balance below 1M gwei"
           description: "Balance (gwei): {{ $labels.balance }}"

--- a/loki/rules/test.yaml
+++ b/loki/rules/test.yaml
@@ -1,0 +1,15 @@
+groups:
+  - name: TestCASRequests
+    interval: 1s
+    rules:
+      - alert: TestCASRequests
+        expr: |
+          sum by (job)
+            (count_over_time({job="cas/access"} | logfmt | method = "GET" [1s]))
+            > 1
+        for: 1s
+        labels:
+            severity: critical
+            category: cas
+        annotations:
+          summary: "This is a test rule from Loki"


### PR DESCRIPTION
Depends on https://github.com/3box/ceramic-infra/pull/247

### Motivation

When we get a discord alert about low eth balance we need to know what environment the alert is coming from (i.e. dev, tnet, prod)

### Changes

- Fixed loki alert rule to fire immediately
- Updated the discord message
  - Includes environment name and current eth balance
- Refactored the alertmanager-discord service

Example (real alert will not be named with "test" and will fire below 1M gwei):
<img width="365" alt="image" src="https://user-images.githubusercontent.com/8445610/108945826-53691900-762b-11eb-8501-cd859fde5e29.png">