### PR TITLE
Feat/scrape configured hosts

### DIFF
--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -3,6 +3,7 @@ FROM prom/prometheus
 ADD prometheus.yml /etc/prometheus/prometheus.yml
 ADD interpolate.sh /etc/prometheus/interpolate.sh
 
+USER root
 RUN /etc/prometheus/interpolate.sh
 
 EXPOSE 9090

--- a/prometheus/Dockerfile
+++ b/prometheus/Dockerfile
@@ -1,5 +1,8 @@
 FROM prom/prometheus
 
 ADD prometheus.yml /etc/prometheus/prometheus.yml
+ADD interpolate.sh /etc/prometheus/interpolate.sh
+
+RUN /etc/prometheus/interpolate.sh
 
 EXPOSE 9090

--- a/prometheus/interpolate.sh
+++ b/prometheus/interpolate.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+#cd /etc/prometheus
+echo "dum"
+
+#sed -i '' -e "s/%%CERAMIC_TARGET%%/$CERAMIC_METRICS_HOST:$METRICS_EXPORTER_PORT/" prometheus.yml
+#sed -i '' -e "s/%%CAS_TARGET%%/$CAS_METRICS_HOST:$METRICS_EXPORTER_PORT/" prometheus.yml

--- a/prometheus/interpolate.sh
+++ b/prometheus/interpolate.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-#cd /etc/prometheus
-echo "dum"
+sed -i -e "s/%%CERAMIC_TARGET%%/$CERAMIC_METRICS_HOST:$METRICS_EXPORTER_PORT/" /etc/prometheus/prometheus.yml
+sed -i -e "s/%%CAS_TARGET%%/$CAS_METRICS_HOST:$METRICS_EXPORTER_PORT/" /etc/prometheus/prometheus.yml
 
-#sed -i '' -e "s/%%CERAMIC_TARGET%%/$CERAMIC_METRICS_HOST:$METRICS_EXPORTER_PORT/" prometheus.yml
-#sed -i '' -e "s/%%CAS_TARGET%%/$CAS_METRICS_HOST:$METRICS_EXPORTER_PORT/" prometheus.yml

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -6,4 +6,4 @@ scrape_configs:
   - job_name: 'stats_agent_scraper'
     metrics_path: '/metrics'
     static_configs:
-      - targets: [ - '127.0.0.1:9464']
+      - targets: [ '127.0.0.1:9464', '%%CERAMIC_TARGET%%', '%%CAS_TARGET%%' ]


### PR DESCRIPTION
The load balancer internal hosts for metrics exported from Ceramic and CAS nodes are generated by the terraform and exported as environment variables to the prometheus container.

Insert env vars for host targets into the prometheus config file so that we can scrape these internal targets.