### PR TITLE
feat(grafana): add cas scheduler dashboards

### DIFF
--- a/grafana/provisioning/dashboards/dev/anchorservice.json
+++ b/grafana/provisioning/dashboards/dev/anchorservice.json
@@ -16,7 +16,7 @@
     "gnetId": null,
     "graphTooltip": 0,
     "id": 4,
-    "iteration": 1642715330379,
+    "iteration": 1666124162784,
     "links": [],
     "panels": [
         {
@@ -32,6 +32,408 @@
             "panels": [],
             "title": "Containers",
             "type": "row"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "CloudWatch",
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 0,
+                "y": 1
+            },
+            "hiddenSeries": false,
+            "id": 49,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.7",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "alias": "",
+                    "dimensions": {
+                        "ClusterName": "ceramic-dev-cas",
+                        "TaskDefinitionFamily": "ceramic-dev-cas-anchor"
+                    },
+                    "expression": "",
+                    "id": "",
+                    "matchExact": true,
+                    "metricName": "CpuUtilized",
+                    "namespace": "ECS/ContainerInsights",
+                    "period": "",
+                    "refId": "A",
+                    "region": "default",
+                    "statistics": [
+                        "SampleCount"
+                    ]
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Anchor Worker Count",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "$$hashKey": "object:1500",
+                    "decimals": 0,
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "$$hashKey": "object:1501",
+                    "format": "none",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "datasource": "CloudWatch",
+            "fieldConfig": {
+                "defaults": {
+                    "color": {
+                        "mode": "thresholds"
+                    },
+                    "mappings": [
+                        {
+                            "from": "",
+                            "id": 1,
+                            "text": "",
+                            "to": "",
+                            "type": 1,
+                            "value": ""
+                        }
+                    ],
+                    "noValue": "0",
+                    "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                            {
+                                "color": "green",
+                                "value": null
+                            },
+                            {
+                                "color": "red",
+                                "value": 80
+                            }
+                        ]
+                    }
+                },
+                "overrides": []
+            },
+            "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 6,
+                "y": 1
+            },
+            "id": 55,
+            "interval": null,
+            "maxDataPoints": null,
+            "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "reduceOptions": {
+                    "calcs": [
+                        "lastNotNull"
+                    ],
+                    "fields": "/^CpuUtilized_SampleCount$/",
+                    "values": false
+                },
+                "text": {},
+                "textMode": "auto"
+            },
+            "pluginVersion": "7.5.7",
+            "targets": [
+                {
+                    "alias": "",
+                    "dimensions": {
+                        "ClusterName": "ceramic-dev-cas",
+                        "TaskDefinitionFamily": "ceramic-dev-cas-anchor"
+                    },
+                    "expression": "",
+                    "id": "",
+                    "matchExact": true,
+                    "metricName": "CpuUtilized",
+                    "namespace": "ECS/ContainerInsights",
+                    "period": "",
+                    "refId": "A",
+                    "region": "default",
+                    "statistics": [
+                        "SampleCount"
+                    ]
+                }
+            ],
+            "timeFrom": "1s",
+            "timeShift": null,
+            "title": "Active Anchor Worker Count",
+            "type": "stat"
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "CloudWatch",
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 12,
+                "y": 1
+            },
+            "hiddenSeries": false,
+            "id": 47,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.7",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "alias": "",
+                    "dimensions": {
+                        "ClusterName": "ceramic-dev-cas",
+                        "TaskDefinitionFamily": "ceramic-dev-cas-anchor"
+                    },
+                    "expression": "",
+                    "id": "",
+                    "matchExact": true,
+                    "metricName": "CpuUtilized",
+                    "namespace": "ECS/ContainerInsights",
+                    "period": "",
+                    "refId": "A",
+                    "region": "default",
+                    "statistics": [
+                        "Average"
+                    ]
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "AnchorWorkerCPU",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "CloudWatch",
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 18,
+                "y": 1
+            },
+            "hiddenSeries": false,
+            "id": 51,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": true
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.7",
+            "pointradius": 2,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "alias": "",
+                    "dimensions": {
+                        "ClusterName": "ceramic-dev-cas",
+                        "TaskDefinitionFamily": "ceramic-dev-cas-anchor"
+                    },
+                    "expression": "",
+                    "id": "",
+                    "matchExact": true,
+                    "metricName": "MemoryUtilized",
+                    "namespace": "ECS/ContainerInsights",
+                    "period": "",
+                    "refId": "A",
+                    "region": "default",
+                    "statistics": [
+                        "Average"
+                    ]
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "AnchorWorkerMemory",
+            "tooltip": {
+                "shared": true,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": true
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
         },
         {
             "alert": {
@@ -65,7 +467,7 @@
                 "for": "5m",
                 "frequency": "2m",
                 "handler": 1,
-                "name": "HealthyHostCount (ceramic-dev-cas) alert",
+                "name": "HealthyHostCount (CAS API) alert",
                 "noDataState": "no_data",
                 "notifications": []
             },
@@ -88,7 +490,7 @@
                 "h": 7,
                 "w": 6,
                 "x": 0,
-                "y": 1
+                "y": 8
             },
             "hiddenSeries": false,
             "id": 22,
@@ -139,26 +541,6 @@
                     "statistics": [
                         "Average"
                     ]
-                },
-                {
-                    "alias": "",
-                    "dimensions": {
-                        "AvailabilityZone": "*",
-                        "LoadBalancer": "app/ceramic-dev-cas-alb-internal/c00b264d49229b9c",
-                        "TargetGroup": "*"
-                    },
-                    "expression": "",
-                    "hide": false,
-                    "id": "",
-                    "matchExact": true,
-                    "metricName": "HealthyHostCount",
-                    "namespace": "AWS/ApplicationELB",
-                    "period": "",
-                    "refId": "B",
-                    "region": "us-east-2",
-                    "statistics": [
-                        "Average"
-                    ]
                 }
             ],
             "thresholds": [
@@ -174,7 +556,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "HealthyHostCount ( CAS )",
+            "title": "HealthyHostCount ( CAS API )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -245,7 +627,7 @@
                 "for": "5m",
                 "frequency": "2m",
                 "handler": 1,
-                "name": "HealthyHostCount ( Ceramic Node ) alert",
+                "name": "RunningCount (CAS Scheduler) alert",
                 "noDataState": "no_data",
                 "notifications": []
             },
@@ -268,7 +650,166 @@
                 "h": 7,
                 "w": 6,
                 "x": 6,
-                "y": 1
+                "y": 8
+            },
+            "hiddenSeries": false,
+            "id": 24,
+            "isNew": true,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": false
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "alias": "",
+                    "dimensions": {
+                        "ClusterName": "ceramic-dev-cas",
+                        "ServiceName": "ceramic-dev-cas-scheduler"
+                    },
+                    "expression": "",
+                    "id": "",
+                    "matchExact": true,
+                    "metricName": "RunningTaskCount",
+                    "namespace": "ECS/ContainerInsights",
+                    "period": "",
+                    "refId": "A",
+                    "region": "us-east-2",
+                    "statistics": [
+                        "Sum"
+                    ]
+                }
+            ],
+            "thresholds": [
+                {
+                    "colorMode": "critical",
+                    "fill": false,
+                    "line": false,
+                    "op": "lt",
+                    "value": 1,
+                    "visible": true
+                }
+            ],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "RunningTaskCount ( CAS Scheduler )",
+            "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "decimals": 0,
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "alert": {
+                "alertRuleTags": {},
+                "conditions": [
+                    {
+                        "evaluator": {
+                            "params": [
+                                1
+                            ],
+                            "type": "lt"
+                        },
+                        "operator": {
+                            "type": "and"
+                        },
+                        "query": {
+                            "params": [
+                                "A",
+                                "5m",
+                                "now"
+                            ]
+                        },
+                        "reducer": {
+                            "params": [],
+                            "type": "avg"
+                        },
+                        "type": "query"
+                    }
+                ],
+                "executionErrorState": "alerting",
+                "for": "5m",
+                "frequency": "2m",
+                "handler": 1,
+                "name": "HealthyHostCount ( CAS Ceramic Node ) alert",
+                "noDataState": "no_data",
+                "notifications": []
+            },
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "CloudWatch",
+            "description": "",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 12,
+                "y": 8
             },
             "hiddenSeries": false,
             "id": 45,
@@ -334,7 +875,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "HealthyHostCount ( Ceramic Node )",
+            "title": "HealthyHostCount ( CAS Ceramic Node )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -374,41 +915,6 @@
             }
         },
         {
-            "alert": {
-                "alertRuleTags": {},
-                "conditions": [
-                    {
-                        "evaluator": {
-                            "params": [
-                                1
-                            ],
-                            "type": "lt"
-                        },
-                        "operator": {
-                            "type": "and"
-                        },
-                        "query": {
-                            "params": [
-                                "A",
-                                "5m",
-                                "now"
-                            ]
-                        },
-                        "reducer": {
-                            "params": [],
-                            "type": "avg"
-                        },
-                        "type": "query"
-                    }
-                ],
-                "executionErrorState": "alerting",
-                "for": "5m",
-                "frequency": "2m",
-                "handler": 1,
-                "name": "HealthyHostCount (ceramic-dev-cas-ipfs) alert",
-                "noDataState": "no_data",
-                "notifications": []
-            },
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
@@ -426,12 +932,12 @@
             "grid": {},
             "gridPos": {
                 "h": 7,
-                "w": 12,
-                "x": 12,
-                "y": 1
+                "w": 6,
+                "x": 18,
+                "y": 8
             },
             "hiddenSeries": false,
-            "id": 24,
+            "id": 52,
             "isNew": true,
             "legend": {
                 "alignAsTable": true,
@@ -501,20 +1007,11 @@
                     ]
                 }
             ],
-            "thresholds": [
-                {
-                    "colorMode": "critical",
-                    "fill": false,
-                    "line": false,
-                    "op": "lt",
-                    "value": 1,
-                    "visible": true
-                }
-            ],
+            "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "HealthyHostCount ( IPFS )",
+            "title": "HealthyHostCount ( CAS IPFS )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -585,7 +1082,7 @@
                 "for": "5m",
                 "frequency": "2m",
                 "handler": 1,
-                "name": "CPUUtilization (ceramic-dev-cas-api) alert",
+                "name": "CPUUtilization (CAS API) alert",
                 "noDataState": "no_data",
                 "notifications": []
             },
@@ -608,7 +1105,7 @@
                 "h": 7,
                 "w": 6,
                 "x": 0,
-                "y": 8
+                "y": 15
             },
             "hiddenSeries": false,
             "id": 26,
@@ -660,26 +1157,6 @@
                         "Maximum",
                         "Minimum"
                     ]
-                },
-                {
-                    "alias": "CPUUtilization_{{ stat }} ({{ ServiceName }})",
-                    "dimensions": {
-                        "ClusterName": "ceramic-dev-cas",
-                        "ServiceName": "ceramic-dev-cas-anchor"
-                    },
-                    "expression": "",
-                    "id": "",
-                    "matchExact": true,
-                    "metricName": "CPUUtilization",
-                    "namespace": "AWS/ECS",
-                    "period": "",
-                    "refId": "B",
-                    "region": "us-east-2",
-                    "statistics": [
-                        "Average",
-                        "Maximum",
-                        "Minimum"
-                    ]
                 }
             ],
             "thresholds": [
@@ -695,7 +1172,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "CPUUtilization ( CAS )",
+            "title": "CPUUtilization ( CAS API )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -766,7 +1243,7 @@
                 "for": "5m",
                 "frequency": "2m",
                 "handler": 1,
-                "name": "CPUUtilization ( Ceramic Node ) alert",
+                "name": "CPUUtilization (CAS Scheduler) alert",
                 "noDataState": "no_data",
                 "notifications": []
             },
@@ -789,7 +1266,167 @@
                 "h": 7,
                 "w": 6,
                 "x": 6,
-                "y": 8
+                "y": 15
+            },
+            "hiddenSeries": false,
+            "id": 28,
+            "isNew": true,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": false
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "alias": "CPUUtilization_{{ stat }} ({{ ServiceName }})",
+                    "dimensions": {
+                        "ClusterName": "ceramic-dev-cas",
+                        "ServiceName": "ceramic-dev-cas-scheduler"
+                    },
+                    "expression": "",
+                    "id": "",
+                    "matchExact": true,
+                    "metricName": "CPUUtilization",
+                    "namespace": "AWS/ECS",
+                    "period": "",
+                    "refId": "A",
+                    "region": "us-east-2",
+                    "statistics": [
+                        "Average",
+                        "Minimum",
+                        "Maximum"
+                    ]
+                }
+            ],
+            "thresholds": [
+                {
+                    "colorMode": "critical",
+                    "fill": false,
+                    "line": false,
+                    "op": "gt",
+                    "value": 80,
+                    "visible": true
+                }
+            ],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CPUUtilization ( CAS Scheduler )",
+            "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "label": null,
+                    "logBase": 1,
+                    "max": 100,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "alert": {
+                "alertRuleTags": {},
+                "conditions": [
+                    {
+                        "evaluator": {
+                            "params": [
+                                80
+                            ],
+                            "type": "gt"
+                        },
+                        "operator": {
+                            "type": "and"
+                        },
+                        "query": {
+                            "params": [
+                                "A",
+                                "5m",
+                                "now"
+                            ]
+                        },
+                        "reducer": {
+                            "params": [],
+                            "type": "avg"
+                        },
+                        "type": "query"
+                    }
+                ],
+                "executionErrorState": "alerting",
+                "for": "5m",
+                "frequency": "2m",
+                "handler": 1,
+                "name": "CPUUtilization ( CAS Ceramic Node ) alert",
+                "noDataState": "no_data",
+                "notifications": []
+            },
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "CloudWatch",
+            "description": "",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 12,
+                "y": 15
             },
             "hiddenSeries": false,
             "id": 43,
@@ -856,7 +1493,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "CPUUtilization ( Ceramic Node )",
+            "title": "CPUUtilization ( CAS Ceramic Node )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -896,41 +1533,6 @@
             }
         },
         {
-            "alert": {
-                "alertRuleTags": {},
-                "conditions": [
-                    {
-                        "evaluator": {
-                            "params": [
-                                80
-                            ],
-                            "type": "gt"
-                        },
-                        "operator": {
-                            "type": "and"
-                        },
-                        "query": {
-                            "params": [
-                                "A",
-                                "5m",
-                                "now"
-                            ]
-                        },
-                        "reducer": {
-                            "params": [],
-                            "type": "avg"
-                        },
-                        "type": "query"
-                    }
-                ],
-                "executionErrorState": "alerting",
-                "for": "5m",
-                "frequency": "2m",
-                "handler": 1,
-                "name": "CPUUtilization (ceramic-dev-cas-ipfs) alert",
-                "noDataState": "no_data",
-                "notifications": []
-            },
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
@@ -948,12 +1550,12 @@
             "grid": {},
             "gridPos": {
                 "h": 7,
-                "w": 12,
-                "x": 12,
-                "y": 8
+                "w": 6,
+                "x": 18,
+                "y": 15
             },
             "hiddenSeries": false,
-            "id": 28,
+            "id": 53,
             "isNew": true,
             "legend": {
                 "alignAsTable": true,
@@ -1004,20 +1606,11 @@
                     ]
                 }
             ],
-            "thresholds": [
-                {
-                    "colorMode": "critical",
-                    "fill": false,
-                    "line": false,
-                    "op": "gt",
-                    "value": 80,
-                    "visible": true
-                }
-            ],
+            "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "CPUUtilization ( IPFS )",
+            "title": "CPUUtilization ( CAS IPFS )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -1087,7 +1680,7 @@
                 "for": "5m",
                 "frequency": "2m",
                 "handler": 1,
-                "name": "MemoryUtilization (ceramic-dev-cas-api) alert",
+                "name": "MemoryUtilization (CAS API) alert",
                 "noDataState": "no_data",
                 "notifications": []
             },
@@ -1110,7 +1703,7 @@
                 "h": 7,
                 "w": 6,
                 "x": 0,
-                "y": 15
+                "y": 22
             },
             "hiddenSeries": false,
             "id": 30,
@@ -1162,26 +1755,6 @@
                         "Maximum",
                         "Minimum"
                     ]
-                },
-                {
-                    "alias": "MemoryUtilization_{{ stat }} ({{ ServiceName }}) ",
-                    "dimensions": {
-                        "ClusterName": "ceramic-dev-cas",
-                        "ServiceName": "ceramic-dev-cas-anchor"
-                    },
-                    "expression": "",
-                    "id": "",
-                    "matchExact": true,
-                    "metricName": "MemoryUtilization",
-                    "namespace": "AWS/ECS",
-                    "period": "",
-                    "refId": "B",
-                    "region": "us-east-2",
-                    "statistics": [
-                        "Average",
-                        "Maximum",
-                        "Minimum"
-                    ]
                 }
             ],
             "thresholds": [
@@ -1197,7 +1770,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "MemoryUtilization ( CAS )",
+            "title": "MemoryUtilization ( CAS API )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -1267,7 +1840,7 @@
                 "for": "5m",
                 "frequency": "2m",
                 "handler": 1,
-                "name": "MemoryUtilization ( Ceramic Node ) alert",
+                "name": "MemoryUtilization (CAS Scheduler) alert",
                 "noDataState": "no_data",
                 "notifications": []
             },
@@ -1290,7 +1863,167 @@
                 "h": 7,
                 "w": 6,
                 "x": 6,
-                "y": 15
+                "y": 22
+            },
+            "hiddenSeries": false,
+            "id": 32,
+            "isNew": true,
+            "legend": {
+                "alignAsTable": true,
+                "avg": true,
+                "current": true,
+                "max": true,
+                "min": true,
+                "rightSide": false,
+                "show": true,
+                "total": false,
+                "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "null",
+            "options": {
+                "alertThreshold": false
+            },
+            "percentage": false,
+            "pluginVersion": "7.5.7",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+                {
+                    "alias": "MemoryUtilization_{{ stat }} ({{ ServiceName }})",
+                    "dimensions": {
+                        "ClusterName": "ceramic-dev-cas",
+                        "ServiceName": "ceramic-dev-cas-scheduler"
+                    },
+                    "expression": "",
+                    "id": "",
+                    "matchExact": true,
+                    "metricName": "MemoryUtilization",
+                    "namespace": "AWS/ECS",
+                    "period": "",
+                    "refId": "A",
+                    "region": "us-east-2",
+                    "statistics": [
+                        "Average",
+                        "Maximum",
+                        "Minimum"
+                    ]
+                }
+            ],
+            "thresholds": [
+                {
+                    "colorMode": "critical",
+                    "fill": false,
+                    "line": false,
+                    "op": "gt",
+                    "value": 80,
+                    "visible": true
+                }
+            ],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "MemoryUtilization ( CAS Scheduler )",
+            "tooltip": {
+                "msResolution": true,
+                "shared": true,
+                "sort": 0,
+                "value_type": "cumulative"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                    "format": "percent",
+                    "label": null,
+                    "logBase": 1,
+                    "max": 100,
+                    "min": 0,
+                    "show": true
+                },
+                {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+        },
+        {
+            "alert": {
+                "alertRuleTags": {},
+                "conditions": [
+                    {
+                        "evaluator": {
+                            "params": [
+                                80
+                            ],
+                            "type": "gt"
+                        },
+                        "operator": {
+                            "type": "and"
+                        },
+                        "query": {
+                            "params": [
+                                "A",
+                                "5m",
+                                "now"
+                            ]
+                        },
+                        "reducer": {
+                            "params": [],
+                            "type": "avg"
+                        },
+                        "type": "query"
+                    }
+                ],
+                "executionErrorState": "alerting",
+                "for": "5m",
+                "frequency": "2m",
+                "handler": 1,
+                "name": "MemoryUtilization ( CAS Ceramic Node ) alert",
+                "noDataState": "no_data",
+                "notifications": []
+            },
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "CloudWatch",
+            "description": "",
+            "editable": true,
+            "error": false,
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+            },
+            "fill": 1,
+            "fillGradient": 0,
+            "grid": {},
+            "gridPos": {
+                "h": 7,
+                "w": 6,
+                "x": 12,
+                "y": 22
             },
             "hiddenSeries": false,
             "id": 44,
@@ -1357,7 +2090,7 @@
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "MemoryUtilization ( Ceramic Node )",
+            "title": "MemoryUtilization ( CAS Ceramic Node )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -1396,41 +2129,6 @@
             }
         },
         {
-            "alert": {
-                "alertRuleTags": {},
-                "conditions": [
-                    {
-                        "evaluator": {
-                            "params": [
-                                80
-                            ],
-                            "type": "gt"
-                        },
-                        "operator": {
-                            "type": "and"
-                        },
-                        "query": {
-                            "params": [
-                                "A",
-                                "5m",
-                                "now"
-                            ]
-                        },
-                        "reducer": {
-                            "params": [],
-                            "type": "avg"
-                        },
-                        "type": "query"
-                    }
-                ],
-                "executionErrorState": "alerting",
-                "for": "5m",
-                "frequency": "2m",
-                "handler": 1,
-                "name": "MemoryUtilization (ceramic-dev-cas-ipfs) alert",
-                "noDataState": "no_data",
-                "notifications": []
-            },
             "aliasColors": {},
             "bars": false,
             "dashLength": 10,
@@ -1448,12 +2146,12 @@
             "grid": {},
             "gridPos": {
                 "h": 7,
-                "w": 12,
-                "x": 12,
-                "y": 15
+                "w": 6,
+                "x": 18,
+                "y": 22
             },
             "hiddenSeries": false,
-            "id": 32,
+            "id": 54,
             "isNew": true,
             "legend": {
                 "alignAsTable": true,
@@ -1504,20 +2202,11 @@
                     ]
                 }
             ],
-            "thresholds": [
-                {
-                    "colorMode": "critical",
-                    "fill": false,
-                    "line": false,
-                    "op": "gt",
-                    "value": 80,
-                    "visible": true
-                }
-            ],
+            "thresholds": [],
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "MemoryUtilization ( IPFS )",
+            "title": "MemoryUtilization ( CAS IPFS )",
             "tooltip": {
                 "msResolution": true,
                 "shared": true,
@@ -1562,7 +2251,7 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 22
+                "y": 29
             },
             "id": 18,
             "panels": [],
@@ -1587,7 +2276,7 @@
                 "h": 9,
                 "w": 12,
                 "x": 0,
-                "y": 23
+                "y": 30
             },
             "hiddenSeries": false,
             "id": 3,
@@ -1692,7 +2381,7 @@
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 23
+                "y": 30
             },
             "hiddenSeries": false,
             "id": 34,
@@ -1811,7 +2500,7 @@
                 "h": 9,
                 "w": 12,
                 "x": 0,
-                "y": 32
+                "y": 39
             },
             "hiddenSeries": false,
             "id": 33,
@@ -1912,7 +2601,7 @@
                 "h": 9,
                 "w": 12,
                 "x": 12,
-                "y": 32
+                "y": 39
             },
             "hiddenSeries": false,
             "id": 6,
@@ -2013,7 +2702,7 @@
                 "h": 9,
                 "w": 24,
                 "x": 0,
-                "y": 41
+                "y": 48
             },
             "hiddenSeries": false,
             "id": 36,
@@ -2123,7 +2812,7 @@
                 "h": 9,
                 "w": 24,
                 "x": 0,
-                "y": 50
+                "y": 57
             },
             "hiddenSeries": false,
             "id": 35,
@@ -2240,7 +2929,7 @@
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 59
+                "y": 66
             },
             "hiddenSeries": false,
             "id": 40,
@@ -2357,7 +3046,7 @@
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 67
+                "y": 74
             },
             "hiddenSeries": false,
             "id": 42,
@@ -2449,7 +3138,7 @@
                 "h": 1,
                 "w": 24,
                 "x": 0,
-                "y": 75
+                "y": 82
             },
             "id": 38,
             "panels": [],
@@ -2523,7 +3212,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 0,
-                "y": 76
+                "y": 83
             },
             "id": 16,
             "options": {
@@ -2631,7 +3320,7 @@
                 "h": 8,
                 "w": 12,
                 "x": 12,
-                "y": 76
+                "y": 83
             },
             "id": 12,
             "options": {
@@ -2718,7 +3407,7 @@
                 "h": 8,
                 "w": 24,
                 "x": 0,
-                "y": 84
+                "y": 91
             },
             "hiddenSeries": false,
             "id": 14,
@@ -2908,5 +3597,5 @@
     "timezone": "",
     "title": "Anchor Service",
     "uid": "dev-U93a07JMz",
-    "version": 6636
+    "version": 6647
 }


### PR DESCRIPTION
- Adds dashboards to show health, cpu, and memory of cas scheduler
- Updates CAS API dashboards to only show internet facing load balancer used for API
-  Updates alert message to be more descriptive
- Adds count for current number of CAS workers active

<img width="1648" alt="Screen Shot 2022-10-18 at 5 28 46 PM" src="https://user-images.githubusercontent.com/8445610/196549500-90672968-09b7-4e09-8c65-049afa18495b.png">
<img width="1656" alt="Screen Shot 2022-10-18 at 5 29 04 PM" src="https://user-images.githubusercontent.com/8445610/196549505-a8bf9afb-c3cb-4729-84d9-e78c44505999.png">

### Notes

If approved for dev I'll update this PR with the same for other envs
