### PR TITLE
use dumb-init to avoid unkillable PID 1

### DIFF
--- a/stats_agent/Dockerfile
+++ b/stats_agent/Dockerfile
@@ -1,8 +1,14 @@
 FROM node:16
+
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_amd64.deb
+RUN dpkg -i dumb-init_*.deb
+
 WORKDIR /usr/src/app
 COPY package*.json tsconfig*.json ./
 RUN npm ci --only-production
 COPY . .
 RUN npm run build
 EXPOSE 9464
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD [ "node", "lib/agent.js" ]


### PR DESCRIPTION
sometimes we need to stop the stats agent, and this is difficult to do when it is PID 1