### PR TITLE
update to use new observability module with working gauges

### DIFF
--- a/stats_agent/package.json
+++ b/stats_agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ceramic-stats_agent",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Typescript implementation of the Ceramic Stats Agent",
   "keywords": [
     "Ceramic",
@@ -35,7 +35,7 @@
     "@ceramicnetwork/common": "^2.1.0",
     "@ceramicnetwork/core": "^2.9.0",
     "@ceramicnetwork/ipfs-daemon": "^2.0.6",
-    "@ceramicnetwork/observability": "^1.0.9",
+    "@ceramicnetwork/observability": "^1.1.0",
     "@ceramicnetwork/streamid": "^2.1.0",
     "@types/d3-array": "^3.0.3",
     "blockcodec-to-ipld-format": "^2.0.0",


### PR DESCRIPTION
Observability package has been updated with a bugfix that enables gauge.observe() call