### PR TITLE
feat: increase cas min eth balance alert

### DIFF
--- a/loki/rules/eth-balance.yaml
+++ b/loki/rules/eth-balance.yaml
@@ -5,12 +5,12 @@ groups:
       - alert: CASLowEthBalance
         expr: |
           sum by (job, balance)
-            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance < 50000000 [10m]))
+            (count_over_time({job="cas/metrics"} |= "walletBalance" | logfmt | balance < 400000000 [10m]))
             > 0
         for: 1s
         labels:
             severity: critical
             category: cas
         annotations:
-          summary: "CAS ETH balance below 50M gwei"
+          summary: "CAS ETH balance below 400M gwei (0.4 eth)"
           description: "Balance (gwei): {{ $labels.balance }}"


### PR DESCRIPTION
Increases from 0.05 eth -> 0.40 eth (50M gwei -> 400M gwei) 

8x increase in current alert, targets leaving 24 hours to resolve alert at recently/currently high gas prices (100-150gwei) 

Additionally leaves enough eth in most instances to execute additional transactions, ie swaps (usdc -> eth). 


